### PR TITLE
fix: mediaplayer attribute error

### DIFF
--- a/plugin/homeassistant.py
+++ b/plugin/homeassistant.py
@@ -324,7 +324,7 @@ class MediaPlayer(Entity):
             getattr(self, source).__doc__ = 'Set Source to "{}"'.format(source)
             getattr(self, source).icon = "radiobox-blank"
         current_source = self.attributes.get("source")
-        if current_source:
+        if current_source and current_source in self.attributes.get("source_list", []):
             getattr(self, current_source).icon = "radiobox-marked"
             getattr(self, current_source).__doc__ = "Currently selected Source."
 


### PR DESCRIPTION
Fix regarding the issues with the MediaPlayer AttributeError: https://github.com/Garulf/HA-Commander/issues/67

![image](https://github.com/user-attachments/assets/41a5a1d7-7b72-420d-81d7-986fbabc2bbe)

---

Copied text from Issue:
<i>
I have analysed the problem a little more. It definitely has something to do with the plugin for controlling Samsung Smart TVs. Unfortunately, this third-party plugin keeps clearing the current playback status. Thus the ```source_list``` is not equal to the ```current_source```. Here is an excerpt from the log, which I have expanded a little.

<b>Source List from my Configuration</b>
> 19:26:05 ERROR (homeassistant.py): Attributes: {'source_list': ['TV', 'Unbekannt (HDMI 1)', 'Unbekannt (HDMI 2)', 'Unbekannt (HDMI 3)', 'ARD-Mediathek', 'ARTE', 'Amazon Prime', 'Joyn', 'Netflix', 'Plex', 'Spotify', 'YouTube', 'ZDF-Mediathek', '01| ARD', '02| ZDF', '03| RTL', '04| Sat.1', '05| ProSieben', '06| RTL ZWEI', '07| Kabel Eins', '08| VOX', '09| SUPER RTL', '10| ProSieben MAXX', '11| DMAX'] [...]

<b>Actual Source, which falls back to the ```app_id```</b>
> 19:26:05 ERROR (homeassistant.py): Attributes: {[...] 'media_title': 'Das Erste HD', 'app_id': 'TV/HDMI', 'source': 'TV/HDMI', [...]

The source list does not contain any attribute that refers to the actual source == ```TV/HDMI```
The error therefore only affects the control of the ```radiobox-marked``` icon and text ```Currently selected Source```. As a simple fix, I would suggest an additional check using the ```source_list``` list. I will create a PR, then the original author can check this again.</i>